### PR TITLE
fix: recover v3 recipients from provenance seed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = [ "crypt_guard_proc"], exclude = ["old"] }
 [package]
 name = "crypt_guard"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 description = "CryptGuard is a post-quantum cryptography framework with NIST FIPS 203/204/205 (ML-KEM, ML-DSA, SLH-DSA) plus legacy Kyber/Falcon/Dilithium, combined with AES and XChaCha20."
 license = "MIT"
@@ -71,7 +71,7 @@ sha2             = "0.10.8"
 chacha20         = "0.9.1"
 once_cell        = "1"
 # The proc-macro crate is released in lockstep with this crate's v3 line.
-crypt_guard_proc = { path = "./crypt_guard_proc", version = "3.0.1" }
+crypt_guard_proc = { path = "./crypt_guard_proc", version = "3.0.2" }
 zeroize          = { version = "1.8.1", features = ["derive"] }
 digest           = "0.10.7"
 generic-array    = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# CryptGuard v3.0.1
+# CryptGuard v3.0.2
 
-[![Crates.io](https://img.shields.io/badge/crates.io-v3.0.1-blue.svg?style=for-the-badge)](https://crates.io/crates/crypt_guard)
+[![Crates.io](https://img.shields.io/badge/crates.io-v3.0.2-blue.svg?style=for-the-badge)](https://crates.io/crates/crypt_guard)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-green.svg?style=for-the-badge)](https://github.com/mm9942/crypt_guard/blob/main/LICENSE)
-[![Documentation](https://img.shields.io/badge/docs-v3.0.1-yellow.svg?style=for-the-badge)](https://docs.rs/crypt_guard/)
+[![Documentation](https://img.shields.io/badge/docs-v3.0.2-yellow.svg?style=for-the-badge)](https://docs.rs/crypt_guard/)
 [![GitHub Library](https://img.shields.io/badge/github-lib-black.svg?style=for-the-badge)](https://github.com/mm9942/crypt_guard)
 
 CryptGuard is a pure-Rust post-quantum cryptography library. Version 3 uses a
@@ -35,7 +35,7 @@ boundaries over compact ciphertexts.
 
 ```toml
 [dependencies]
-crypt_guard = "3.0.1"
+crypt_guard = "3.0.2"
 ```
 
 The default feature set includes the FIPS ML-KEM and ML-DSA backends. No
@@ -270,7 +270,7 @@ explicit migration build.
 
 ```toml
 [dependencies]
-crypt_guard = { version = "3.0.1", features = ["cgv2-compat"] }
+crypt_guard = { version = "3.0.2", features = ["cgv2-compat"] }
 ```
 
 Migration procedure:
@@ -323,4 +323,10 @@ Dilithium path for explicitly managed legacy data. It is separate from
 - [FIPS 204: ML-DSA](https://csrc.nist.gov/pubs/fips/204/final)
 - [FIPS 205: SLH-DSA](https://csrc.nist.gov/pubs/fips/205/final)
 - [RFC 9180: Hybrid Public Key Encryption](https://www.rfc-editor.org/rfc/rfc9180.html)
-- [draft-ietf-hpke-pq-05](https://datatracker.ietf.org/doc/draft-ietf-hpke-pq-05/)
+
+## Release note: v3.0.2
+
+This release removes a v3 provenance-recovery bug: a caller now retains its
+validated 32-byte provenance seed and deterministically rederives the
+recipient key pair when opening an envelope. It must not persist the
+KEM-specific, internally expanded recipient-private representation.

--- a/crypt_guard_proc/Cargo.toml
+++ b/crypt_guard_proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypt_guard_proc"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 description = "CryptGuardProc is the proc macro crate related to CryptGuardLib, which is a comprehensive Rust library designed for strong encryption and decryption, incorporating post-quantum cryptography to safeguard against quantum threats. It's geared towards developers who need to embed advanced cryptographic capabilities in their Rust applications."
 license = "MIT"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "crypt_guard_examples"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 description = "Examples for the crypt_guard safe API and legacy compatibility paths."
 license = "MIT"
 repository = "https://github.com/mm9942/crypt_guard"
 
 [dependencies]
-crypt_guard = { path = "..", version = "3.0.1" }
+crypt_guard = { path = "..", version = "3.0.2" }

--- a/src/hpke_pq/mod.rs
+++ b/src/hpke_pq/mod.rs
@@ -2546,7 +2546,13 @@ pub mod draft_ietf_hpke_pq_05_full {
             self.kem
         }
 
-        /// Borrow the 64-byte seed only for protected key-storage integration.
+        /// Borrow the KEM-specific private-key seed for controlled key-storage
+        /// integration.
+        ///
+        /// This is operational recipient material, not an application's
+        /// provenance seed. A caller recovering a recipient through
+        /// [`derive_recipient_key_pair`] must retain its original validated
+        /// 32-byte input and must not replace it with these bytes.
         pub fn as_seed_bytes(&self) -> &[u8] {
             match &self.inner {
                 RecipientPrivateKeyInner::MlKem512(value) => value.as_bytes(),
@@ -2651,6 +2657,102 @@ pub mod draft_ietf_hpke_pq_05_full {
                 })
             }
         }
+    }
+
+    /// Deterministically derive a recipient key pair from exactly 32 seed bytes.
+    ///
+    /// This is intended for reproducible key recovery from protected external
+    /// keying material, not for ordinary key generation. Persist the exact
+    /// validated 32-byte caller seed and invoke this function again when a
+    /// recipient key is needed; do **not** persist
+    /// [`RecipientPrivateKey::as_seed_bytes`] as provenance material. Some KEM
+    /// implementations use a larger private-key seed internally. The caller
+    /// seed is expanded with SHAKE256 under a crypt_guard v3 domain separator
+    /// and the selected KEM identifier before it reaches any KEM-specific
+    /// derivation. Use [`generate_recipient_key_pair`] for fresh
+    /// OS-CSPRNG-generated keys.
+    ///
+    /// The returned error intentionally identifies only an invalid seed format;
+    /// it never includes seed material.
+    pub fn derive_recipient_key_pair(kem: Kem, seed: &[u8]) -> Result<RecipientKeyPair, Error> {
+        require_kem(kem)?;
+        let seed = derive_recipient_key_seed(kem, seed)?;
+
+        match kem {
+            Kem::MlKem512 => {
+                let (public_key, private_key) =
+                    derive_key_pair_512(&seed[..]).map_err(|_| Error::InternalInvariant)?;
+                Ok(RecipientKeyPair {
+                    public_key: RecipientPublicKey {
+                        kem,
+                        inner: RecipientPublicKeyInner::MlKem512(Box::new(public_key)),
+                    },
+                    private_key: RecipientPrivateKey {
+                        kem,
+                        inner: RecipientPrivateKeyInner::MlKem512(private_key),
+                    },
+                })
+            }
+            Kem::MlKem768 => {
+                let (public_key, private_key) =
+                    derive_key_pair(&seed[..]).map_err(|_| Error::InternalInvariant)?;
+                Ok(RecipientKeyPair {
+                    public_key: RecipientPublicKey {
+                        kem,
+                        inner: RecipientPublicKeyInner::MlKem768(Box::new(public_key)),
+                    },
+                    private_key: RecipientPrivateKey {
+                        kem,
+                        inner: RecipientPrivateKeyInner::MlKem768(private_key),
+                    },
+                })
+            }
+            Kem::MlKem1024 => {
+                let (public_key, private_key) =
+                    derive_key_pair_1024(&seed[..]).map_err(|_| Error::InternalInvariant)?;
+                Ok(RecipientKeyPair {
+                    public_key: RecipientPublicKey {
+                        kem,
+                        inner: RecipientPublicKeyInner::MlKem1024(Box::new(public_key)),
+                    },
+                    private_key: RecipientPrivateKey {
+                        kem,
+                        inner: RecipientPrivateKeyInner::MlKem1024(private_key),
+                    },
+                })
+            }
+            Kem::MlKem768P256 | Kem::MlKem1024P384 | Kem::MlKem768X25519 => {
+                let private_key = HybridPrivateKey::from_seed(kem, seed);
+                let public_key = HybridPublicKey::derive(kem, private_key.as_seed_bytes())?;
+                Ok(RecipientKeyPair {
+                    public_key: RecipientPublicKey {
+                        kem,
+                        inner: RecipientPublicKeyInner::Hybrid(public_key),
+                    },
+                    private_key: RecipientPrivateKey {
+                        kem,
+                        inner: RecipientPrivateKeyInner::Hybrid(private_key),
+                    },
+                })
+            }
+        }
+    }
+
+    fn derive_recipient_key_seed(
+        kem: Kem,
+        seed: &[u8],
+    ) -> Result<Zeroizing<[u8; HYBRID_SEED_BYTES]>, Error> {
+        let seed = <[u8; HYBRID_SEED_BYTES]>::try_from(seed)
+            .map(Zeroizing::new)
+            .map_err(|_| Error::InvalidRecipientPrivateKey)?;
+        let mut xof = Shake256::default();
+        xof.update(b"crypt_guard/v3/pq-hpke/recipient-key-pair");
+        xof.update(&kem.id().to_be_bytes());
+        xof.update(&seed[..]);
+
+        let mut derived = Zeroizing::new([0_u8; HYBRID_SEED_BYTES]);
+        xof.finalize_xof().read(&mut derived[..]);
+        Ok(derived)
     }
 
     #[derive(Clone, Eq, PartialEq)]
@@ -3840,6 +3942,52 @@ mod tests {
                     .unwrap(),
                 decode(&export.exported_value),
             );
+        }
+    }
+
+    #[test]
+    fn v3_recipient_key_pair_derivation_is_deterministic_for_every_operational_kem() {
+        use draft_ietf_hpke_pq_05_full::{derive_recipient_key_pair, Kem};
+
+        let seed = [0x5a_u8; 32];
+        for kem in [
+            Kem::MlKem512,
+            Kem::MlKem768,
+            Kem::MlKem1024,
+            Kem::MlKem768P256,
+            Kem::MlKem1024P384,
+            Kem::MlKem768X25519,
+        ] {
+            let first = derive_recipient_key_pair(kem, &seed)
+                .expect("every operational KEM must support deterministic recipient derivation");
+            let second = derive_recipient_key_pair(kem, &seed)
+                .expect("repeated deterministic recipient derivation must succeed");
+
+            assert_eq!(first.public_key().kem(), kem);
+            assert_eq!(first.private_key().kem(), kem);
+            assert_eq!(
+                first.public_key().as_bytes(),
+                second.public_key().as_bytes()
+            );
+            assert_eq!(
+                first.private_key().as_seed_bytes(),
+                second.private_key().as_seed_bytes()
+            );
+        }
+    }
+
+    #[test]
+    fn v3_recipient_key_pair_derivation_rejects_non_32_byte_seeds_without_echoing_them() {
+        use draft_ietf_hpke_pq_05_full::{derive_recipient_key_pair, Error, Kem};
+
+        for length in [31, 33] {
+            let seed = vec![0xa5_u8; length];
+            let error = match derive_recipient_key_pair(Kem::MlKem768, &seed) {
+                Ok(_) => panic!("a non-32-byte seed must be rejected"),
+                Err(error) => error,
+            };
+            assert_eq!(error, Error::InvalidRecipientPrivateKey);
+            assert_eq!(format!("{error:?}"), "InvalidRecipientPrivateKey");
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! # CryptGuard v3.0.1
+//! # CryptGuard v3.0.2
 //!
 //! CryptGuard v3 makes [`pq_hpke`] the default post-quantum encryption
 //! transport. Its default profile is ML-KEM-1024/P-384, SHAKE256, and

--- a/src/pq_hpke.rs
+++ b/src/pq_hpke.rs
@@ -15,11 +15,11 @@ use core::convert::TryInto;
 use std::{error::Error as StdError, fmt};
 
 pub use crate::hpke_pq::draft_ietf_hpke_pq_05_full::{
-    generate_recipient_key_pair, setup_base_receiver as setup_base_receiver_inner,
-    setup_base_sender as setup_base_sender_inner, setup_psk_receiver as setup_psk_receiver_inner,
-    setup_psk_sender as setup_psk_sender_inner, Aead, Capability, Encapsulation, Error, Kdf, Kem,
-    RecipientContext, RecipientKeyPair, RecipientPrivateKey, RecipientPublicKey, SenderContext,
-    Suite,
+    derive_recipient_key_pair, generate_recipient_key_pair,
+    setup_base_receiver as setup_base_receiver_inner, setup_base_sender as setup_base_sender_inner,
+    setup_psk_receiver as setup_psk_receiver_inner, setup_psk_sender as setup_psk_sender_inner,
+    Aead, Capability, Encapsulation, Error, Kdf, Kem, RecipientContext, RecipientKeyPair,
+    RecipientPrivateKey, RecipientPublicKey, SenderContext, Suite,
 };
 
 /// The revision implemented by this crate's PQ KEM adapter.
@@ -310,6 +310,13 @@ fn suite_from_ids(kem: u16, kdf: u16, aead: u16) -> Result<Suite, EnvelopeError>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn derived_key_pair_is_publicly_reexported() {
+        let derive: fn(Kem, &[u8]) -> Result<RecipientKeyPair, Error> =
+            crate::pq_hpke::derive_recipient_key_pair;
+        let _ = derive;
+    }
 
     #[test]
     fn default_profile_round_trip_binds_info_and_aad() {

--- a/tests/pq_hpke_v3.rs
+++ b/tests/pq_hpke_v3.rs
@@ -1,9 +1,48 @@
 //! Public v3 PQ HPKE transport contracts.
 
 use crypt_guard::pq_hpke::{
-    generate_recipient_key_pair, setup_base_receiver, setup_base_sender, EnvelopeError, Error,
-    HpkeEnvelope, DEFAULT_SUITE,
+    derive_recipient_key_pair, generate_recipient_key_pair, setup_base_receiver, setup_base_sender,
+    Aead, EnvelopeError, Error, HpkeEnvelope, Kdf, Kem, Suite, DEFAULT_SUITE,
 };
+
+#[test]
+fn provenance_seed_rederives_v3_recipient_for_open_without_persisting_private_material() {
+    // This is the only secret material a provenance store retains. In
+    // particular, it is not the 64-byte ML-KEM recipient seed created inside
+    // the v3 derivation path.
+    let provenance_seed = [0x4d_u8; 32];
+    let suite = Suite::new(Kem::MlKem768, Kdf::Shake256, Aead::ChaCha20Poly1305);
+
+    let sealing_pair = derive_recipient_key_pair(suite.kem(), &provenance_seed)
+        .expect("a validated provenance seed must derive a v3 recipient");
+    assert_eq!(sealing_pair.private_key().as_seed_bytes().len(), 64);
+    assert_ne!(sealing_pair.private_key().as_seed_bytes(), provenance_seed);
+    let envelope = HpkeEnvelope::seal(
+        suite,
+        sealing_pair.public_key(),
+        b"Harw provenance record",
+        b"provenance-bound AAD",
+        b"payload opened after rederivation",
+    )
+    .expect("derived recipient must seal");
+    drop(sealing_pair);
+
+    // Model an open after process restart: rederive from the retained original
+    // 32-byte seed, rather than serializing the internal recipient private
+    // representation.
+    let opening_pair = derive_recipient_key_pair(suite.kem(), &provenance_seed)
+        .expect("the retained provenance seed must rederive the same recipient");
+    assert_eq!(
+        envelope
+            .open(
+                opening_pair.private_key(),
+                b"Harw provenance record",
+                b"provenance-bound AAD",
+            )
+            .expect("rederived recipient must open"),
+        b"payload opened after rederivation"
+    );
+}
 
 #[test]
 fn default_envelope_round_trip_preserves_the_default_profile() {


### PR DESCRIPTION
## Summary
- add a public 32-byte provenance-seed derivation API for v3 recipient recovery
- rederive recipient key pairs on open instead of treating KEM-specific private material as provenance state
- release 3.0.2 across manifests and README; remove the unreachable draft reference

## Root cause
The v3 recipient representation can use KEM-specific private material larger than Harw's fixed 32-byte provenance seed. Persisting that representation crossed the provenance boundary incorrectly.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `CARGO_HOME=/tmp/crypt-guard-cargo-home cargo --config 'build.rustc-wrapper=""' test`
- `CARGO_HOME=/tmp/crypt-guard-cargo-home cargo --config 'build.rustc-wrapper=""' package --manifest-path crypt_guard_proc/Cargo.toml --allow-dirty --offline`